### PR TITLE
Restrict fees

### DIFF
--- a/amm/contracts/stable_pool/lib.rs
+++ b/amm/contracts/stable_pool/lib.rs
@@ -112,8 +112,8 @@ pub mod stable_pool {
 
     #[ink(event)]
     pub struct FeeChanged {
-        trade_fee_bps: u16,
-        protocol_fee_bps: u16,
+        trade_fee: u32,
+        protocol_fee: u32,
     }
 
     #[ink::storage_item]
@@ -208,8 +208,8 @@ pub mod stable_pool {
             tokens_decimals: Vec<u8>,
             init_amp_coef: u128,
             owner: AccountId,
-            trade_fee_bps: u16,
-            protocol_fee_bps: u16,
+            trade_fee: u32,
+            protocol_fee: u32,
             fee_receiver: Option<AccountId>,
         ) -> Result<Self, StablePoolError> {
             let token_rates = vec![TokenRate::new_constant(RATE_PRECISION); tokens.len()];
@@ -219,7 +219,7 @@ pub mod stable_pool {
                 token_rates,
                 init_amp_coef,
                 owner,
-                Fees::new(trade_fee_bps, protocol_fee_bps),
+                Fees::new(trade_fee, protocol_fee),
                 fee_receiver,
             )
         }
@@ -233,8 +233,8 @@ pub mod stable_pool {
             rate_expiration_duration_ms: u64,
             init_amp_coef: u128,
             owner: AccountId,
-            trade_fee_bps: u16,
-            protocol_fee_bps: u16,
+            trade_fee: u32,
+            protocol_fee: u32,
             fee_receiver: Option<AccountId>,
         ) -> Result<Self, StablePoolError> {
             let current_time = Self::env().block_timestamp();
@@ -256,7 +256,7 @@ pub mod stable_pool {
                 token_rates,
                 init_amp_coef,
                 owner,
-                Fees::new(trade_fee_bps, protocol_fee_bps),
+                Fees::new(trade_fee, protocol_fee),
                 fee_receiver,
             )
         }
@@ -799,17 +799,13 @@ pub mod stable_pool {
         }
 
         #[ink(message)]
-        fn set_fees(
-            &mut self,
-            trade_fee_bps: u16,
-            protocol_fee_bps: u16,
-        ) -> Result<(), StablePoolError> {
+        fn set_fees(&mut self, trade_fee: u32, protocol_fee: u32) -> Result<(), StablePoolError> {
             self.ensure_owner()?;
             self.pool.fees =
-                Fees::new(trade_fee_bps, protocol_fee_bps).ok_or(StablePoolError::InvalidFee)?;
+                Fees::new(trade_fee, protocol_fee).ok_or(StablePoolError::InvalidFee)?;
             self.env().emit_event(FeeChanged {
-                trade_fee_bps,
-                protocol_fee_bps,
+                trade_fee,
+                protocol_fee,
             });
             Ok(())
         }
@@ -845,11 +841,8 @@ pub mod stable_pool {
         }
 
         #[ink(message)]
-        fn fees(&self) -> (u16, u16) {
-            (
-                self.pool.fees.trade_fee_bps,
-                self.pool.fees.protocol_fee_bps,
-            )
+        fn fees(&self) -> (u32, u32) {
+            (self.pool.fees.trade_fee, self.pool.fees.protocol_fee)
         }
 
         #[ink(message)]

--- a/amm/drink-tests/src/stable_swap_tests/mod.rs
+++ b/amm/drink-tests/src/stable_swap_tests/mod.rs
@@ -12,7 +12,7 @@ use drink::{self, runtime::MinimalRuntime, session::Session, AccountId32};
 use ink_primitives::AccountId;
 use ink_wrapper_types::{Connection, ToAccountId};
 
-pub const FEE_BPS_DENOM: u128 = 10_000;
+pub const FEE_DENOM: u128 = 1_000_000_000;
 
 pub const RATE_PRECISION: u128 = 10u128.pow(12);
 
@@ -32,8 +32,8 @@ pub fn setup_stable_swap_with_tokens(
     token_decimals: Vec<u8>,
     token_supply: Vec<u128>,
     amp_coef: u128,
-    fee_bps: u16,
-    protocol_fee_bps: u16,
+    trade_fee: u32,
+    protocol_trade_fee: u32,
     caller: AccountId32,
 ) -> (AccountId, Vec<AccountId>) {
     let _ = session.set_actor(caller);
@@ -67,8 +67,8 @@ pub fn setup_stable_swap_with_tokens(
         token_decimals,
         amp_coef,
         bob(),
-        fee_bps,
-        protocol_fee_bps,
+        trade_fee,
+        protocol_trade_fee,
         Some(fee_receiver()),
     );
 

--- a/amm/drink-tests/src/stable_swap_tests/mod.rs
+++ b/amm/drink-tests/src/stable_swap_tests/mod.rs
@@ -12,6 +12,7 @@ use drink::{self, runtime::MinimalRuntime, session::Session, AccountId32};
 use ink_primitives::AccountId;
 use ink_wrapper_types::{Connection, ToAccountId};
 
+/// Fee denominator. Fees are expressed in 1e9 precision (1_000_000_000 is 100%)
 pub const FEE_DENOM: u128 = 1_000_000_000;
 
 pub const RATE_PRECISION: u128 = 10u128.pow(12);

--- a/amm/drink-tests/src/utils.rs
+++ b/amm/drink-tests/src/utils.rs
@@ -58,8 +58,8 @@ pub mod stable_swap {
         tokens_decimals: Vec<u8>,
         init_amp_coef: u128,
         caller: drink::AccountId32,
-        trade_fee_bps: u16,
-        protocol_fee_bps: u16,
+        trade_fee: u32,
+        protocol_fee: u32,
         fee_receiver: Option<AccountId>,
     ) -> stable_pool_contract::Instance {
         let _ = session.set_actor(caller.clone());
@@ -68,8 +68,8 @@ pub mod stable_swap {
             tokens_decimals,
             init_amp_coef,
             caller.to_account_id(),
-            trade_fee_bps,
-            protocol_fee_bps,
+            trade_fee,
+            protocol_fee,
             fee_receiver,
         );
 
@@ -90,15 +90,17 @@ pub mod stable_swap {
         to: AccountId,
     ) -> Result<(u128, u128), StablePoolError> {
         _ = session.set_actor(caller);
-        handle_ink_error(session
-            .execute(
-                stable_pool_contract::Instance::from(stable_pool).add_liquidity(
-                    min_share_amount,
-                    amounts,
-                    to,
-                ),
-            )
-            .unwrap())
+        handle_ink_error(
+            session
+                .execute(
+                    stable_pool_contract::Instance::from(stable_pool).add_liquidity(
+                        min_share_amount,
+                        amounts,
+                        to,
+                    ),
+                )
+                .unwrap(),
+        )
     }
 
     pub fn remove_liquidity_by_amounts(
@@ -110,15 +112,17 @@ pub mod stable_swap {
         to: AccountId,
     ) -> Result<(u128, u128), StablePoolError> {
         _ = session.set_actor(caller);
-        handle_ink_error(session
-            .execute(
-                stable_pool_contract::Instance::from(stable_pool).remove_liquidity_by_amounts(
-                    max_share_amount,
-                    amounts,
-                    to,
-                ),
-            )
-            .unwrap())
+        handle_ink_error(
+            session
+                .execute(
+                    stable_pool_contract::Instance::from(stable_pool).remove_liquidity_by_amounts(
+                        max_share_amount,
+                        amounts,
+                        to,
+                    ),
+                )
+                .unwrap(),
+        )
     }
 
     pub fn remove_liquidity_by_shares(
@@ -235,7 +239,7 @@ pub mod stable_swap {
         )
     }
 
-    pub fn fees(session: &mut Session<MinimalRuntime>, stable_pool: AccountId) -> (u16, u16) {
+    pub fn fees(session: &mut Session<MinimalRuntime>, stable_pool: AccountId) -> (u32, u32) {
         handle_ink_error(
             session
                 .query(stable_pool_contract::Instance::from(stable_pool).fees())

--- a/amm/traits/stable_pool.rs
+++ b/amm/traits/stable_pool.rs
@@ -19,9 +19,9 @@ pub trait StablePoolView {
     #[ink(message)]
     fn amp_coef(&self) -> u128;
 
-    /// Returns current trade and protocol fees in BPS.
+    /// Returns current trade and protocol fees in 1e9 precision.
     #[ink(message)]
-    fn fees(&self) -> (u16, u16);
+    fn fees(&self) -> (u32, u32);
 
     /// Updates cached token rates if expired and
     /// returns current tokens rates with precision of 12 decimal places.
@@ -185,11 +185,14 @@ pub trait StablePool {
     #[ink(message)]
     fn set_fee_receiver(&mut self, fee_receiver: Option<AccountId>) -> Result<(), StablePoolError>;
 
+    /// Set fees
+    /// - trade_fee given as an integer with 1e9 precision. The the maximum is 1% (10000000)
+    /// - protocol_fee given as an integer with 1e9 precision. The maximum is 50% (500000000)
     #[ink(message)]
     fn set_fees(
         &mut self,
-        trade_fee_bps: u16,
-        protocol_fee_bps: u16,
+        trade_fee: u32,
+        protocol_fee: u32,
     ) -> Result<(), StablePoolError>;
 
     #[ink(message)]

--- a/helpers/constants.rs
+++ b/helpers/constants.rs
@@ -13,8 +13,9 @@ pub mod stable_pool {
     pub const MAX_AMP: u128 = 1_000_000;
 
     /// Given as an integer with 1e9 precision (1%)
-    pub const MAX_TRADE_FEE: u32 = 10000000;
+    pub const MAX_TRADE_FEE: u32 = 10_000_000;
     /// Given as an integer with 1e9 precision (50%)
-    pub const MAX_PROTOCOL_FEE: u32 = 500000000;
+    pub const MAX_PROTOCOL_FEE: u32 = 500_000_000;
+    /// Fee denominator
     pub const FEE_DENOM: u32 = 1_000_000_000;
 }

--- a/helpers/constants.rs
+++ b/helpers/constants.rs
@@ -11,4 +11,10 @@ pub mod stable_pool {
     pub const MIN_AMP: u128 = 1;
     /// Max amplification coefficient.
     pub const MAX_AMP: u128 = 1_000_000;
+
+    /// Given as an integer with 1e9 precision (1%)
+    pub const MAX_TRADE_FEE: u32 = 10000000;
+    /// Given as an integer with 1e9 precision (50%)
+    pub const MAX_PROTOCOL_FEE: u32 = 500000000;
+    pub const FEE_DENOM: u32 = 1_000_000_000;
 }

--- a/helpers/constants.rs
+++ b/helpers/constants.rs
@@ -15,6 +15,9 @@ pub mod stable_pool {
     /// Given as an integer with 1e9 precision (1%)
     pub const MAX_TRADE_FEE: u32 = 10_000_000;
     /// Given as an integer with 1e9 precision (50%)
+    ///
+    /// It is taken as part of the trade fee thus,
+    /// a maximum 50% of 1% goes to the protocol (0.5% of the trade)
     pub const MAX_PROTOCOL_FEE: u32 = 500_000_000;
     /// Fee denominator
     pub const FEE_DENOM: u32 = 1_000_000_000;

--- a/helpers/stable_swap_math/fees.rs
+++ b/helpers/stable_swap_math/fees.rs
@@ -1,6 +1,7 @@
-use crate::math::{casted_mul, MathError};
-
-pub const FEE_DENOM: u32 = 1_000_000_000;
+use crate::{
+    constants::stable_pool::{FEE_DENOM, MAX_PROTOCOL_FEE, MAX_TRADE_FEE},
+    math::{casted_mul, MathError},
+};
 
 #[ink::storage_item]
 #[derive(Debug, Default)]
@@ -14,7 +15,7 @@ impl Fees {
     /// - trade_fee given as an integer with 1e9 precision. The the maximum is 1% (10000000)
     /// - protocol_fee given as an integer with 1e9 precision. The maximum is 50% (500000000)
     pub fn new(trade_fee: u32, protocol_fee: u32) -> Option<Self> {
-        if trade_fee > FEE_DENOM / 100 || protocol_fee > FEE_DENOM / 2 {
+        if trade_fee > MAX_TRADE_FEE || protocol_fee > MAX_PROTOCOL_FEE {
             None
         } else {
             Some(Self {

--- a/helpers/stable_swap_math/fees.rs
+++ b/helpers/stable_swap_math/fees.rs
@@ -12,8 +12,8 @@ pub struct Fees {
 
 impl Fees {
     /// Crate new fee instance.
-    /// - trade_fee given as an integer with 1e9 precision. The the maximum is 1% (10000000)
-    /// - protocol_fee given as an integer with 1e9 precision. The maximum is 50% (500000000)
+    /// - trade_fee given as an integer with 1e9 precision restricted to [`MAX_TRADE_FEE`](const@MAX_TRADE_FEE)
+    /// - protocol_fee given as an integer with 1e9 precision restricted to [`MAX_PROTOCOL_FEE`](const@MAX_PROTOCOL_FEE)
     pub fn new(trade_fee: u32, protocol_fee: u32) -> Option<Self> {
         if trade_fee > MAX_TRADE_FEE || protocol_fee > MAX_PROTOCOL_FEE {
             None

--- a/helpers/stable_swap_math/fees.rs
+++ b/helpers/stable_swap_math/fees.rs
@@ -12,8 +12,9 @@ pub struct Fees {
 
 impl Fees {
     /// Crate new fee instance.
-    /// - trade_fee given as an integer with 1e9 precision restricted to [`MAX_TRADE_FEE`](const@MAX_TRADE_FEE)
-    /// - protocol_fee given as an integer with 1e9 precision restricted to [`MAX_PROTOCOL_FEE`](const@MAX_PROTOCOL_FEE)
+    /// - `trade_fee` given as an integer with 1e9 precision restricted to [`MAX_TRADE_FEE`](const@MAX_TRADE_FEE)
+    /// - `protocol_fee` given as an integer with 1e9 precision restricted to [`MAX_PROTOCOL_FEE`](const@MAX_PROTOCOL_FEE).
+    ///    Taken as part of the `trade_fee`
     pub fn new(trade_fee: u32, protocol_fee: u32) -> Option<Self> {
         if trade_fee > MAX_TRADE_FEE || protocol_fee > MAX_PROTOCOL_FEE {
             None

--- a/helpers/stable_swap_math/fees.rs
+++ b/helpers/stable_swap_math/fees.rs
@@ -1,58 +1,61 @@
 use crate::math::{casted_mul, MathError};
 
-pub const FEE_BPS_DENOM: u16 = 10_000;
+pub const FEE_DENOM: u32 = 1_000_000_000;
 
 #[ink::storage_item]
 #[derive(Debug, Default)]
 pub struct Fees {
-    pub trade_fee_bps: u16,
-    pub protocol_fee_bps: u16,
+    pub trade_fee: u32,
+    pub protocol_fee: u32,
 }
 
 impl Fees {
-    pub fn new(total_fee_bps: u16, protocol_fee_bps: u16) -> Option<Self> {
-        if total_fee_bps > FEE_BPS_DENOM || protocol_fee_bps > FEE_BPS_DENOM {
+    /// Crate new fee instance.
+    /// - trade_fee given as an integer with 1e9 precision. The the maximum is 1% (10000000)
+    /// - protocol_fee given as an integer with 1e9 precision. The maximum is 50% (500000000)
+    pub fn new(trade_fee: u32, protocol_fee: u32) -> Option<Self> {
+        if trade_fee > FEE_DENOM / 100 || protocol_fee > FEE_DENOM / 2 {
             None
         } else {
             Some(Self {
-                trade_fee_bps: total_fee_bps,
-                protocol_fee_bps,
+                trade_fee,
+                protocol_fee,
             })
         }
     }
 
     pub fn zero() -> Self {
         Self {
-            trade_fee_bps: 0,
-            protocol_fee_bps: 0,
+            trade_fee: 0,
+            protocol_fee: 0,
         }
     }
 
     pub fn trade_fee_from_gross(&self, amount: u128) -> Result<u128, MathError> {
-        u128_ratio(amount, self.trade_fee_bps, FEE_BPS_DENOM)
+        u128_ratio(amount, self.trade_fee, FEE_DENOM)
     }
 
     pub fn trade_fee_from_net(&self, amount: u128) -> Result<u128, MathError> {
         u128_ratio(
             amount,
-            self.trade_fee_bps,
-            FEE_BPS_DENOM
-                .checked_sub(self.trade_fee_bps)
+            self.trade_fee,
+            FEE_DENOM
+                .checked_sub(self.trade_fee)
                 .ok_or(MathError::SubUnderflow(61))?,
         )
     }
 
     pub fn protocol_trade_fee(&self, amount: u128) -> Result<u128, MathError> {
-        u128_ratio(amount, self.protocol_fee_bps, FEE_BPS_DENOM)
+        u128_ratio(amount, self.protocol_fee, FEE_DENOM)
     }
 
     /// Used to normalize fee applied on difference amount with ideal u128, This logic is from
     /// https://github.com/ref-finance/ref-contracts/blob/main/ref-exchange/src/stable_swap/math.rs#L48
     /// https://github.com/saber-hq/stable-swap/blob/5db776fb0a41a0d1a23d46b99ef412ca7ccc5bf6/stable-swap-program/program/src/fees.rs#L73
     /// https://github.com/curvefi/curve-contract/blob/e5fb8c0e0bcd2fe2e03634135806c0f36b245511/tests/simulation.py#L124
-    pub fn normalized_trade_fee(&self, num_coins: u16, amount: u128) -> Result<u128, MathError> {
+    pub fn normalized_trade_fee(&self, num_coins: u32, amount: u128) -> Result<u128, MathError> {
         let adjusted_trade_fee = (self
-            .trade_fee_bps
+            .trade_fee
             .checked_mul(num_coins)
             .ok_or(MathError::MulOverflow(61)))?
         .checked_div(
@@ -61,11 +64,11 @@ impl Fees {
                 .ok_or(MathError::MulOverflow(62))?,
         )
         .ok_or(MathError::DivByZero(61))?;
-        u128_ratio(amount, adjusted_trade_fee, FEE_BPS_DENOM)
+        u128_ratio(amount, adjusted_trade_fee, FEE_DENOM)
     }
 }
 
-fn u128_ratio(amount: u128, num: u16, denom: u16) -> Result<u128, MathError> {
+fn u128_ratio(amount: u128, num: u32, denom: u32) -> Result<u128, MathError> {
     casted_mul(amount, num.into())
         .checked_div(denom.into())
         .ok_or(MathError::DivByZero(61))?


### PR DESCRIPTION
Restrict 
- max `trade_fee`  to `1%`
- max `protocol_fee` to  `50%`

Fees are expressed with 1e9 precision (`1_000_000_000` is `100%`)