### PR TITLE
Restrict max coins

### DIFF
--- a/amm/contracts/stable_pool/lib.rs
+++ b/amm/contracts/stable_pool/lib.rs
@@ -2,8 +2,10 @@
 mod token_rate;
 /// Stabelswap implementation based on the CurveFi stableswap model.
 ///
-/// This pool contract supports PSP22 tokens which value increases at some
-/// on-chain discoverable rate in terms of some other token, e.g. AZERO x sAZERO.
+/// This pool contract supports up to 8 PSP22 tokens.
+///
+/// Supports tokens which value increases at some on-chain discoverable rate
+/// in terms of some other token, e.g. AZERO x sAZERO.
 /// The rate oracle contract must implement [`RateProvider`](trait@traits::RateProvider).
 ///
 /// IMPORTANT:
@@ -13,7 +15,9 @@ mod token_rate;
 pub mod stable_pool {
     use crate::token_rate::TokenRate;
     use amm_helpers::{
-        constants::stable_pool::{MAX_AMP, MIN_AMP, RATE_PRECISION, TOKEN_TARGET_DECIMALS},
+        constants::stable_pool::{
+            MAX_AMP, MAX_COINS, MIN_AMP, RATE_PRECISION, TOKEN_TARGET_DECIMALS,
+        },
         ensure,
         stable_swap_math::{self as math, fees::Fees},
     };
@@ -172,7 +176,7 @@ pub mod stable_pool {
             ensure!(
                 token_count == tokens_decimals.len()
                     && token_count == token_rates.len()
-                    && token_count > 1,
+                    && (2..=MAX_COINS).contains(&token_count),
                 StablePoolError::IncorrectTokenCount
             );
 

--- a/helpers/constants.rs
+++ b/helpers/constants.rs
@@ -21,4 +21,7 @@ pub mod stable_pool {
     pub const MAX_PROTOCOL_FEE: u32 = 500_000_000;
     /// Fee denominator
     pub const FEE_DENOM: u32 = 1_000_000_000;
+
+    /// Maximum number coins (PSP22 token contracts) in the pool.
+    pub const MAX_COINS: usize = 8;
 }


### PR DESCRIPTION
Restrict the maximum number of coins (PSP22 token contracts) in the pool.