### PR TITLE
2-step ownership transfer

### DIFF
--- a/amm/contracts/stable_pool/lib.rs
+++ b/amm/contracts/stable_pool/lib.rs
@@ -110,6 +110,9 @@ pub mod stable_pool {
     }
 
     #[ink(event)]
+    pub struct OwnershipRenounced {}
+
+    #[ink(event)]
     pub struct FeeReceiverChanged {
         #[ink(topic)]
         pub new_fee_receiver: Option<AccountId>,
@@ -1081,6 +1084,14 @@ pub mod stable_pool {
             self.ownable.accept_ownership(new_owner)?;
             self.env()
                 .emit_event(TransferOwnershipAccepted { new_owner });
+            Ok(())
+        }
+
+        #[ink(message)]
+        fn renounce_ownership(&mut self) -> Ownable2StepResult<()> {
+            self.ownable
+                .renounce_ownership(self.env().caller(), self.env().account_id())?;
+            self.env().emit_event(OwnershipRenounced {});
             Ok(())
         }
 

--- a/amm/traits/lib.rs
+++ b/amm/traits/lib.rs
@@ -1,10 +1,12 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
+mod ownable2step;
 mod rate_provider;
 mod stable_pool;
 
 pub type Balance = <ink::env::DefaultEnvironment as ink::env::Environment>::Balance;
 
 pub use amm_helpers::math::MathError;
+pub use ownable2step::{Ownable2Step, Ownable2StepData, Ownable2StepError, Ownable2StepResult};
 pub use rate_provider::RateProvider;
 pub use stable_pool::{StablePool, StablePoolError, StablePoolView};

--- a/amm/traits/ownable2step.rs
+++ b/amm/traits/ownable2step.rs
@@ -1,0 +1,106 @@
+use ink::{prelude::string::String, primitives::AccountId};
+use scale::{Decode, Encode};
+
+/// Implement this trait to enable two-step ownership trasfer process in your contract.
+///
+/// The process looks like this:
+/// * current owner (Alice) calls `self.transfer_ownership(bob)`,
+/// * the contract still has the owner: Alice and a pending owner: bob,
+/// * when Bob claims the ownership by calling `self.accept_ownership()` he becomes the new owner and pending owner is removed.
+///
+/// The methods are all wrapper in `Ownable2StepResult` to make it possible to use them in settings where the `Data` is e.g. behid `Lazy`.
+#[ink::trait_definition]
+pub trait Ownable2Step {
+    /// Returns the address of the current owner.
+    #[ink(message)]
+    fn get_owner(&self) -> Ownable2StepResult<AccountId>;
+
+    /// Returns the address of the pending owner.
+    #[ink(message)]
+    fn get_pending_owner(&self) -> Ownable2StepResult<AccountId>;
+
+    /// Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one.
+    /// Can only be called by the current owner.
+    #[ink(message)]
+    fn transfer_ownership(&mut self, new_owner: AccountId) -> Ownable2StepResult<()>;
+
+    /// The new owner accepts the ownership transfer.
+    #[ink(message)]
+    fn accept_ownership(&mut self) -> Ownable2StepResult<()>;
+
+    /// Return error if called by any account other than the owner.
+    #[ink(message)]
+    fn ensure_owner(&self) -> Ownable2StepResult<()>;
+}
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum Ownable2StepError {
+    /// The caller didn't have the permissions to call a given method
+    CallerNotOwner(AccountId),
+    /// The caller tried to accept ownership but caller in not the pending owner
+    CallerNotPendingOwner(AccountId),
+    /// The caller tried to accept ownership but the process hasn't been started
+    NoPendingOwner,
+    /// Useful in cases, when the `Data` struct is not accessed directly but inside of `Lazy` or a `Mapping`, means that we failed to access the `Data` struct itself.
+    Custom(String),
+}
+
+pub type Ownable2StepResult<T> = Result<T, Ownable2StepError>;
+
+#[derive(Debug)]
+#[ink::storage_item]
+pub struct Ownable2StepData {
+    owner: AccountId,
+    pending_owner: Option<AccountId>,
+}
+
+impl Ownable2StepData {
+    pub fn new(owner: AccountId) -> Self {
+        Self {
+            owner,
+            pending_owner: None,
+        }
+    }
+
+    pub fn transfer_ownership(
+        &mut self,
+        caller: AccountId,
+        new_owner: AccountId,
+    ) -> Ownable2StepResult<()> {
+        self.ensure_owner(caller)?;
+        self.pending_owner = Some(new_owner);
+        Ok(())
+    }
+
+    pub fn accept_ownership(&mut self, caller: AccountId) -> Ownable2StepResult<()> {
+        let pending_owner = self
+            .pending_owner
+            .ok_or(Ownable2StepError::NoPendingOwner)?;
+
+        if caller != pending_owner {
+            return Err(Ownable2StepError::CallerNotPendingOwner(caller));
+        }
+
+        self.owner = pending_owner;
+        self.pending_owner = None;
+
+        Ok(())
+    }
+
+    pub fn get_owner(&self) -> Ownable2StepResult<AccountId> {
+        Ok(self.owner)
+    }
+
+    pub fn get_pending_owner(&self) -> Ownable2StepResult<AccountId> {
+        self.pending_owner.ok_or(Ownable2StepError::NoPendingOwner)
+    }
+
+    pub fn ensure_owner(&self, caller: AccountId) -> Ownable2StepResult<()> {
+        if caller != self.owner {
+            Err(Ownable2StepError::CallerNotOwner(caller))
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/amm/traits/ownable2step.rs
+++ b/amm/traits/ownable2step.rs
@@ -7,7 +7,7 @@ use scale::{Decode, Encode};
 /// * current owner (Alice) calls `self.transfer_ownership(bob)`,
 /// * the contract still has the owner: Alice and a pending owner: bob,
 /// * when Bob claims the ownership by calling `self.accept_ownership()` he becomes the new owner and pending owner is removed.
-/// 
+///
 /// The ownership can be also renounced:
 /// * current owner calls `self.transfer_ownership(this_contract_address)`
 /// * current owner calls `self.renounce_ownership()` - transfers the ownership to
@@ -83,9 +83,7 @@ impl Ownable2StepData {
     }
 
     pub fn accept_ownership(&mut self, caller: AccountId) -> Ownable2StepResult<()> {
-        let pending_owner = self
-            .pending_owner
-            .ok_or(Ownable2StepError::NoPendingOwner)?;
+        let pending_owner = self.get_pending_owner()?;
 
         if caller != pending_owner {
             return Err(Ownable2StepError::CallerNotPendingOwner(caller));
@@ -103,9 +101,7 @@ impl Ownable2StepData {
         contract_address: AccountId,
     ) -> Ownable2StepResult<()> {
         self.ensure_owner(caller)?;
-        let pending_owner = self
-            .pending_owner
-            .ok_or(Ownable2StepError::NoPendingOwner)?;
+        let pending_owner = self.get_pending_owner()?;
         if pending_owner != contract_address {
             return Err(Ownable2StepError::ContractNotPendingOwner(pending_owner));
         }

--- a/amm/traits/stable_pool.rs
+++ b/amm/traits/stable_pool.rs
@@ -3,7 +3,7 @@ use ink::primitives::AccountId;
 use ink::LangError;
 use psp22::PSP22Error;
 
-use crate::MathError;
+use crate::{MathError, Ownable2StepError};
 
 #[ink::trait_definition]
 pub trait StablePoolView {
@@ -180,9 +180,6 @@ pub trait StablePool {
     // --- OWNER RESTRICTED FUNCTIONS --- //
 
     #[ink(message)]
-    fn set_owner(&mut self, new_owner: AccountId) -> Result<(), StablePoolError>;
-
-    #[ink(message)]
     fn set_fee_receiver(&mut self, fee_receiver: Option<AccountId>) -> Result<(), StablePoolError>;
 
     /// Set fees
@@ -202,6 +199,7 @@ pub trait StablePool {
 #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub enum StablePoolError {
+    Ownable2StepError(Ownable2StepError),
     MathError(MathError),
     PSP22Error(PSP22Error),
     LangError(LangError),
@@ -217,7 +215,6 @@ pub enum StablePoolError {
     IncorrectTokenCount,
     TooLargeTokenDecimal,
     InvalidFee,
-    OnlyOwner,
 }
 
 impl From<PSP22Error> for StablePoolError {
@@ -235,5 +232,11 @@ impl From<LangError> for StablePoolError {
 impl From<MathError> for StablePoolError {
     fn from(error: MathError) -> Self {
         StablePoolError::MathError(error)
+    }
+}
+
+impl From<Ownable2StepError> for StablePoolError {
+    fn from(error: Ownable2StepError) -> Self {
+        StablePoolError::Ownable2StepError(error)
     }
 }


### PR DESCRIPTION
Currently, the `owner` of the contract has the privilege to change several crucial parameters of the pool contract.

This PR is one of the solutions to increase the security of the protocol. See other solution #27 

Allow 2-step process of the ownership transfer to increase the security of the protocol.
Ideally, the `owner` role will be controlled by a multisig account to increase the decentralization of the power.