### PR TITLE
Split access roles

### DIFF
--- a/amm/drink-tests/src/stable_swap_tests/mod.rs
+++ b/amm/drink-tests/src/stable_swap_tests/mod.rs
@@ -67,10 +67,13 @@ pub fn setup_stable_swap_with_tokens(
         tokens.clone(),
         token_decimals,
         amp_coef,
-        bob(),
         trade_fee,
         protocol_trade_fee,
         Some(fee_receiver()),
+        // for the sake of tests, BOB is granted all access roles
+        bob(),
+        bob(),
+        bob(),
     );
 
     let stable_swap: stable_pool_contract::Instance = session

--- a/amm/drink-tests/src/utils.rs
+++ b/amm/drink-tests/src/utils.rs
@@ -54,23 +54,28 @@ pub mod stable_swap {
 
     pub fn setup(
         session: &mut Session<MinimalRuntime>,
+        caller: drink::AccountId32,
         tokens: Vec<AccountId>,
         tokens_decimals: Vec<u8>,
         init_amp_coef: u128,
-        caller: drink::AccountId32,
         trade_fee: u32,
         protocol_fee: u32,
         fee_receiver: Option<AccountId>,
+        fee_setter: AccountId,
+        fee_receiver_setter: AccountId,
+        amp_coef_setter: AccountId,
     ) -> stable_pool_contract::Instance {
         let _ = session.set_actor(caller.clone());
         let instance = stable_pool_contract::Instance::new_stable(
             tokens,
             tokens_decimals,
             init_amp_coef,
-            caller.to_account_id(),
             trade_fee,
             protocol_fee,
             fee_receiver,
+            fee_setter,
+            fee_receiver_setter,
+            amp_coef_setter,
         );
 
         session

--- a/amm/traits/stable_pool.rs
+++ b/amm/traits/stable_pool.rs
@@ -177,10 +177,16 @@ pub trait StablePool {
     #[ink(message)]
     fn force_update_rate(&mut self);
 
-    // --- OWNER RESTRICTED FUNCTIONS --- //
+    // --- ACCESS RESTRICTED FUNCTIONS --- //
 
     #[ink(message)]
-    fn set_owner(&mut self, new_owner: AccountId) -> Result<(), StablePoolError>;
+    fn set_fee_setter(&mut self, new_fee_setter: AccountId) -> Result<(), StablePoolError>;
+
+    #[ink(message)]
+    fn set_fee_receiver_setter(&mut self, new_fee_receiver_setter: AccountId) -> Result<(), StablePoolError>;
+
+    #[ink(message)]
+    fn set_amp_coef_setter(&mut self, new_amp_coef_setter: AccountId) -> Result<(), StablePoolError>;
 
     #[ink(message)]
     fn set_fee_receiver(&mut self, fee_receiver: Option<AccountId>) -> Result<(), StablePoolError>;


### PR DESCRIPTION
Currently, the `owner` of the contract has the privilege to change several crucial parameters of the pool contract.

This PR is one of the solutions to increase the security of the protocol. See other solution #26

Instead of one `owner` role which has control over all the parameters of the pool contract, split access to several roles.