### PR TITLE
Combine StablePool traits into one

### DIFF
--- a/amm/contracts/mock_sazero_rate/lib.rs
+++ b/amm/contracts/mock_sazero_rate/lib.rs
@@ -11,7 +11,9 @@ mod mock_sazero_rate {
         #[ink(constructor)]
         #[allow(clippy::new_without_default)]
         pub fn new() -> Self {
-            Self { rate: 10u128.pow(12u32) }
+            Self {
+                rate: 10u128.pow(12u32),
+            }
         }
 
         #[ink(message)]

--- a/amm/contracts/stable_pool/lib.rs
+++ b/amm/contracts/stable_pool/lib.rs
@@ -310,7 +310,7 @@ pub mod stable_pool {
         /// NOTE:
         /// If the pool contains a token with rate oracle, this function makes
         /// a cross-contract call to the `RateProvider` contract if the cached rate is expired.
-        /// This means that the gas cost of the contract methods that use this function may change,
+        /// This means that the gas cost of the contract methods that use this function may vary,
         /// depending on the state of the expiration timestamp of the cached rate.
         fn update_rates(&mut self) {
             let current_time = self.env().block_timestamp();

--- a/amm/contracts/stable_pool/token_rate.rs
+++ b/amm/contracts/stable_pool/token_rate.rs
@@ -33,7 +33,7 @@ impl TokenRate {
             token_rate_contract,
             expiration_duration_ms,
         ));
-        _ = rate.update_rate_no_cache(current_time);
+        _ = rate.force_update_rate(current_time);
         rate
     }
 
@@ -60,7 +60,7 @@ impl TokenRate {
     /// Update rate without expiry check.
     ///
     /// Returns `true` if value of the new rate is different than the previous.
-    pub fn update_rate_no_cache(&mut self, current_time: u64) -> bool {
+    pub fn force_update_rate(&mut self, current_time: u64) -> bool {
         match self {
             Self::External(external) => external.update_rate_no_cache(current_time),
             Self::Constant(_) => false,

--- a/amm/drink-tests/src/stable_swap_tests/mod.rs
+++ b/amm/drink-tests/src/stable_swap_tests/mod.rs
@@ -5,7 +5,6 @@ use primitive_types::U256;
 
 pub use stable_pool_contract::StablePool as _;
 pub use stable_pool_contract::StablePoolError;
-pub use stable_pool_contract::StablePoolView as _;
 
 use drink::{self, runtime::MinimalRuntime, session::Session, AccountId32};
 

--- a/amm/drink-tests/src/utils.rs
+++ b/amm/drink-tests/src/utils.rs
@@ -50,7 +50,7 @@ pub fn upload_all(session: &mut Session<MinimalRuntime>) {
 
 pub mod stable_swap {
     use super::*;
-    use stable_pool_contract::{StablePool as _, StablePoolError, StablePoolView as _};
+    use stable_pool_contract::{StablePool as _, StablePoolError};
 
     pub fn setup(
         session: &mut Session<MinimalRuntime>,

--- a/amm/traits/lib.rs
+++ b/amm/traits/lib.rs
@@ -9,4 +9,4 @@ pub type Balance = <ink::env::DefaultEnvironment as ink::env::Environment>::Bala
 pub use amm_helpers::math::MathError;
 pub use ownable2step::{Ownable2Step, Ownable2StepData, Ownable2StepError, Ownable2StepResult};
 pub use rate_provider::RateProvider;
-pub use stable_pool::{StablePool, StablePoolError, StablePoolView};
+pub use stable_pool::{StablePool, StablePoolError};

--- a/amm/traits/ownable2step.rs
+++ b/amm/traits/ownable2step.rs
@@ -33,7 +33,7 @@ pub trait Ownable2Step {
 
     /// The owner of the contract renounces the ownership.
     /// To start the process, the owner has to initiate ownership transfer to this contract's address.
-    /// Can anly be caller by the current owner.
+    /// Can only be called by the current owner.
     #[ink(message)]
     fn renounce_ownership(&mut self) -> Ownable2StepResult<()>;
 

--- a/amm/traits/stable_pool.rs
+++ b/amm/traits/stable_pool.rs
@@ -65,7 +65,7 @@ pub trait StablePool {
         amounts: Vec<u128>,
     ) -> Result<(u128, u128), StablePoolError>;
 
-    /// Estimate ideal deposit amounts required
+    /// Calculate ideal deposit amounts required
     /// to mint `liquidity` amount of lp tokens
     /// Returns required deposit amounts
     #[ink(message)]
@@ -83,7 +83,7 @@ pub trait StablePool {
         amounts: Vec<u128>,
     ) -> Result<(u128, u128), StablePoolError>;
 
-    /// Estimate ideal withdraw amounts for
+    /// Calculate ideal withdraw amounts for
     /// burning `liquidity` amount of lp tokens
     /// Returns withdraw amounts
     #[ink(message)]

--- a/amm/traits/stable_pool.rs
+++ b/amm/traits/stable_pool.rs
@@ -32,9 +32,9 @@ pub trait StablePool {
     #[ink(message)]
     fn token_rates(&mut self) -> Vec<u128>;
 
-    /// Calculate swap amount of token_out
-    /// given token_in amount.
-    /// Returns a tuple of (amount_out, fee)
+    /// Calculate swap amount of `token_out`
+    /// given `token_in amount`.
+    /// Returns a tuple of (amount out, fee)
     /// NOTE: fee is applied on `token_out`
     #[ink(message)]
     fn get_swap_amount_out(
@@ -44,9 +44,9 @@ pub trait StablePool {
         token_in_amount: u128,
     ) -> Result<(u128, u128), StablePoolError>;
 
-    /// Calculate required amount of `token_in`
-    /// fo swap, to `token_out amount`.
-    /// Returns a tuple of (amount_in, fee)
+    /// Calculate required swap amount of `token_in`
+    /// to get `token_out_amount`.
+    /// Returns a tuple of (amount in, fee)
     /// NOTE: fee is applied on `token_out`
     #[ink(message)]
     fn get_swap_amount_in(
@@ -92,7 +92,7 @@ pub trait StablePool {
         liquidity: u128,
     ) -> Result<Vec<u128>, StablePoolError>;
 
-    /// Deposit `amounts` of tokens to receive lpt tokens to `to`.
+    /// Deposit `amounts` of tokens to receive lpt tokens to `to` account.
     /// Caller must allow enough spending allowance of underlying tokens
     /// for this contract.
     /// Returns an error if the minted LP tokens amount is less

--- a/amm/traits/stable_pool.rs
+++ b/amm/traits/stable_pool.rs
@@ -6,7 +6,7 @@ use psp22::PSP22Error;
 use crate::{MathError, Ownable2StepError};
 
 #[ink::trait_definition]
-pub trait StablePoolView {
+pub trait StablePool {
     /// Returns list of tokens in the pool.
     #[ink(message)]
     fn tokens(&self) -> Vec<AccountId>;
@@ -23,6 +23,10 @@ pub trait StablePoolView {
     #[ink(message)]
     fn fees(&self) -> (u32, u32);
 
+    /// Protocol fees receiver (if any)
+    #[ink(message)]
+    fn fee_receiver(&self) -> Option<AccountId>;
+
     /// Updates cached token rates if expired and
     /// returns current tokens rates with precision of 12 decimal places.
     #[ink(message)]
@@ -30,23 +34,23 @@ pub trait StablePoolView {
 
     /// Calculate swap amount of token_out
     /// given token_in amount.
-    /// Returns (amount_out, fee)
-    /// NOTE: fee is applied to token_out
+    /// Returns a tuple of (amount_out, fee)
+    /// NOTE: fee is applied on `token_out`
     #[ink(message)]
     fn get_swap_amount_out(
-        &mut self,
+        &self,
         token_in: AccountId,
         token_out: AccountId,
         token_in_amount: u128,
     ) -> Result<(u128, u128), StablePoolError>;
 
-    /// Calculate required amount of token_in
-    /// given swap token_out amount
-    /// Returns (amount_in, fee)
-    /// fee is applied to token_out
+    /// Calculate required amount of `token_in`
+    /// fo swap, to `token_out amount`.
+    /// Returns a tuple of (amount_in, fee)
+    /// NOTE: fee is applied on `token_out`
     #[ink(message)]
     fn get_swap_amount_in(
-        &mut self,
+        &self,
         token_in: AccountId,
         token_out: AccountId,
         token_out_amount: u128,
@@ -54,14 +58,14 @@ pub trait StablePoolView {
 
     /// Calculate how many lp tokens will be minted
     /// given deposit `amounts`.
-    /// Returns (lp_amount, fee)
+    /// Returns a tuple of (lpt amount, fee)
     #[ink(message)]
     fn get_mint_liquidity_for_amounts(
-        &mut self,
+        &self,
         amounts: Vec<u128>,
     ) -> Result<(u128, u128), StablePoolError>;
 
-    /// Calculate ideal deposit amounts required
+    /// Estimate ideal deposit amounts required
     /// to mint `liquidity` amount of lp tokens
     /// Returns required deposit amounts
     #[ink(message)]
@@ -72,14 +76,14 @@ pub trait StablePoolView {
 
     /// Calculate how many lp tokens will be burned
     /// given withdraw `amounts`.
-    /// Returns (lp_amount, fee)
+    /// Returns a tuple of (lpt amount, fee part)
     #[ink(message)]
     fn get_burn_liquidity_for_amounts(
-        &mut self,
+        &self,
         amounts: Vec<u128>,
     ) -> Result<(u128, u128), StablePoolError>;
 
-    /// Calculate ideal withdraw amounts for
+    /// Estimate ideal withdraw amounts for
     /// burning `liquidity` amount of lp tokens
     /// Returns withdraw amounts
     #[ink(message)]
@@ -87,16 +91,13 @@ pub trait StablePoolView {
         &mut self,
         liquidity: u128,
     ) -> Result<Vec<u128>, StablePoolError>;
-}
 
-#[ink::trait_definition]
-pub trait StablePool {
-    /// Mints LP tokens to `to` account from imbalanced `amounts`.
-    /// `to` account must allow enough spending allowance of underlying tokens
+    /// Deposit `amounts` of tokens to receive lpt tokens to `to`.
+    /// Caller must allow enough spending allowance of underlying tokens
     /// for this contract.
     /// Returns an error if the minted LP tokens amount is less
     /// than `min_share_amount`.
-    /// Returns (minted_share_amount, fee_part)
+    /// Returns a tuple of (minted lpt amount, fee)
     #[ink(message)]
     fn add_liquidity(
         &mut self,
@@ -107,7 +108,7 @@ pub trait StablePool {
 
     /// Burns LP tokens and withdraws underlying tokens to `to` account
     /// in imbalanced `amounts`.
-    /// Returns (burned_share_amount, fee_part)
+    /// Returns a tuple of (burned lpt amount, fee part)
     #[ink(message)]
     fn remove_liquidity_by_amounts(
         &mut self,
@@ -116,9 +117,9 @@ pub trait StablePool {
         to: AccountId,
     ) -> Result<(u128, u128), StablePoolError>;
 
-    /// Burns LP tokens and withdraws underlying tokens in balanced amounts to `to` account.
+    /// Burns lp tokens and withdraws underlying tokens in balanced amounts to `to` account.
     /// Fails if any of the amounts received is less than in `min_amounts`.
-    /// Returns (amounts_out, fee_part)
+    /// Returns withdrawal amounts
     #[ink(message)]
     fn remove_liquidity_by_shares(
         &mut self,
@@ -129,11 +130,12 @@ pub trait StablePool {
 
     /// Swaps token_in to token_out.
     /// Swapped tokens are transferred to the `to` account.
-    /// caller account must allow enough spending allowance of token_in
+    /// caller account must allow enough spending allowance of `token_in`
     /// for this contract.
-    /// Returns an error if swapped token_out amount is less than
+    /// Returns an error if swapped `token_out` amount is less than
     /// `min_token_out_amount`.
-    /// Returns (token_out_amount, fee_amount)
+    /// NOTE: Fee is applied on `token_out`.
+    /// Returns a tuple of (token out amount, fee amount)
     #[ink(message)]
     fn swap_exact_in(
         &mut self,
@@ -146,12 +148,12 @@ pub trait StablePool {
 
     /// Swaps token_in to token_out.
     /// Swapped tokens are transferred to the `to` account.
-    /// caller account must allow enough spending allowance of token_out
+    /// Caller account must allow enough spending allowance of `token_in`
     /// for this contract.
-    /// Returns an error if to get token_out_amount of token_out it is required
-    /// to spend more than `max_token_in_amount` of token_in.
-    /// NOTE: Fee is applied to `token_out`.
-    /// Returns (token_in_amount, fee_amount)
+    /// Returns an error if it is required to spend more than
+    /// `max_token_in_amount`  to get `token_out_amount`.
+    /// NOTE: Fee is applied on `token_out`.
+    /// Returns a tuple of (token in amount, fee amount)
     #[ink(message)]
     fn swap_exact_out(
         &mut self,
@@ -164,7 +166,7 @@ pub trait StablePool {
 
     /// Swaps excess reserve balance of `token_in` to `token_out`.
     /// Swapped tokens are transferred to the `to` account.
-    /// Returns (token_out_amount, fee_amount)
+    /// Returns a tuple of (token out amount, fee amount)
     #[ink(message)]
     fn swap_received(
         &mut self,
@@ -174,8 +176,10 @@ pub trait StablePool {
         to: AccountId,
     ) -> Result<(u128, u128), StablePoolError>;
 
+    /// Update cached rates without expiry check.
+    /// Can be called by anyone.
     #[ink(message)]
-    fn force_update_rate(&mut self);
+    fn force_update_rates(&mut self);
 
     // --- OWNER RESTRICTED FUNCTIONS --- //
 
@@ -210,7 +214,7 @@ pub enum StablePoolError {
     InsufficientLiquidityMinted,
     InsufficientLiquidityBurned,
     InsufficientOutputAmount,
-    TooLargeInputAmount,
+    InsufficientLiquidity,
     InsufficientInputAmount,
     IncorrectTokenCount,
     TooLargeTokenDecimal,

--- a/helpers/stable_swap_math/mod.rs
+++ b/helpers/stable_swap_math/mod.rs
@@ -325,7 +325,7 @@ pub fn rated_swap_from(
 }
 
 /// Given `deposit_amounts` user want deposit, calculates how many lpt
-/// is required to be burnt.
+/// are required to be minted.
 /// Returns a tuple of (lpt to mint, fee)
 fn compute_lp_amount_for_deposit(
     deposit_amounts: &Vec<u128>,
@@ -458,7 +458,7 @@ pub fn compute_amounts_given_lp(
 }
 
 /// Given `withdraw_amounts` user want get, calculates how many lpt
-/// is required to be burnt
+/// are required to be burnt
 /// Returns a tuple of (lpt to burn, fee part)
 fn compute_lp_amount_for_withdraw(
     withdraw_amounts: &[u128],

--- a/helpers/stable_swap_math/mod.rs
+++ b/helpers/stable_swap_math/mod.rs
@@ -119,7 +119,7 @@ fn compute_d_next(
 }
 
 /// Returns new reserve of `token_y_id`
-/// given new reserve of `token_x_id` tokens
+/// given new reserve of `token_x_id`.
 ///
 /// NOTE: it does not check if `token_x_id` != `token_y_id` and if tokens' `id`s are out of bounds
 fn compute_y(

--- a/helpers/stable_swap_math/mod.rs
+++ b/helpers/stable_swap_math/mod.rs
@@ -118,8 +118,8 @@ fn compute_d_next(
         .ok_or(MathError::DivByZero(2))
 }
 
-/// Returns new reserve of `y` tokens
-/// given new reserve of `x` tokens
+/// Returns new reserve of `token_y_id`
+/// given new reserve of `token_x_id` tokens
 ///
 /// NOTE: it does not check if `token_x_id` != `token_y_id` and if tokens' `id`s are out of bounds
 fn compute_y(
@@ -202,30 +202,30 @@ fn compute_y_next(y_prev: U256, b: U256, c: U256, d: U256) -> Result<U256, MathE
         .ok_or(MathError::DivByZero(7))
 }
 
-/// Compute SwapResult after an exchange given `amount_in` of the `token_in_id`.
+/// Compute swap result after an exchange given `token_amount_in` of the `token_in_id`.
 /// panics if token ids are out of bounds.
-/// Returns (amount_out, fee_amount)
+/// Returns a tuple of (amount out, fee amount)
 /// NOTE: it does not check if `token_in_id` != `token_out_id`.
 fn swap_to(
-    token_in_idx: usize,
+    token_in_id: usize,
     token_in_amount: u128,
-    token_out_idx: usize,
+    token_out_id: usize,
     current_reserves: &Vec<u128>,
     fees: &Fees,
     amp_coef: u128,
 ) -> Result<(u128, u128), MathError> {
     let y = compute_y(
         token_in_amount
-            .checked_add(current_reserves[token_in_idx])
+            .checked_add(current_reserves[token_in_id])
             .ok_or(MathError::AddOverflow(9))?,
         current_reserves,
-        token_in_idx,
-        token_out_idx,
+        token_in_id,
+        token_out_id,
         amp_coef,
     )?;
     // sub 1 in case there are any rounding errors
     // https://github.com/curvefi/curve-contract/blob/b0bbf77f8f93c9c5f4e415bce9cd71f0cdee960e/contracts/pool-templates/base/SwapTemplateBase.vy#L466
-    let dy = current_reserves[token_out_idx]
+    let dy = current_reserves[token_out_id]
         .checked_sub(y)
         .ok_or(MathError::SubUnderflow(7))?
         .checked_sub(1)
@@ -239,38 +239,38 @@ fn swap_to(
 
 pub fn rated_swap_to(
     rates: &[u128],
-    token_in_idx: usize,
+    token_in_id: usize,
     token_in_amount: u128,
-    token_out_idx: usize,
+    token_out_id: usize,
     current_reserves: &[u128],
     fees: &Fees,
     amp_coef: u128,
 ) -> Result<(u128, u128), MathError> {
-    let r_token_in_amount = amount_to_rated(token_in_amount, rates[token_in_idx])?;
+    let r_token_in_amount = amount_to_rated(token_in_amount, rates[token_in_id])?;
     let r_current_reserves = amounts_to_rated(current_reserves, rates)?;
 
     let (r_amount_swapped, r_fee) = swap_to(
-        token_in_idx,
+        token_in_id,
         r_token_in_amount,
-        token_out_idx,
+        token_out_id,
         &r_current_reserves,
         fees,
         amp_coef,
     )?;
 
-    let amount_swapped = amount_from_rated(r_amount_swapped, rates[token_out_idx])?;
-    let fee = amount_from_rated(r_fee, rates[token_out_idx])?;
+    let amount_swapped = amount_from_rated(r_amount_swapped, rates[token_out_id])?;
+    let fee = amount_from_rated(r_fee, rates[token_out_id])?;
     Ok((amount_swapped, fee))
 }
 
-/// Compute SwapResult after an exchange given `amount_out` of the `token_out_id`
+/// Compute swap result after an exchange given `token_amount_out` of the `token_out_id`
 /// panics if token ids are out of bounds
-/// Returns (amount_in, fee_amount)
+/// Returns a tuple (amount in, fee amount)
 /// NOTE: it does not check if `token_in_id` != `token_out_id`
 fn swap_from(
-    token_in_idx: usize,
+    token_in_id: usize,
     token_out_amount: u128, // Net amount (w/o fee)
-    token_out_idx: usize,
+    token_out_id: usize,
     current_reserves: &Vec<u128>,
     fees: &Fees,
     amp_coef: u128,
@@ -282,16 +282,16 @@ fn swap_from(
         .ok_or(MathError::AddOverflow(11))?;
 
     let y = compute_y(
-        current_reserves[token_out_idx]
+        current_reserves[token_out_id]
             .checked_sub(token_out_amount_plus_fee)
             .ok_or(MathError::SubUnderflow(12))?,
         current_reserves,
-        token_out_idx,
-        token_in_idx,
+        token_out_id,
+        token_in_id,
         amp_coef,
     )?;
     let dy: u128 = y
-        .checked_sub(current_reserves[token_in_idx])
+        .checked_sub(current_reserves[token_in_id])
         .ok_or(MathError::SubUnderflow(13))?;
 
     Ok((dy, fee))
@@ -299,33 +299,34 @@ fn swap_from(
 
 pub fn rated_swap_from(
     rates: &[u128],
-    token_in_idx: usize,
+    token_in_id: usize,
     token_out_amount: u128,
-    token_out_idx: usize,
+    token_out_id: usize,
     current_reserves: &[u128],
     fees: &Fees,
     amp_coef: u128,
 ) -> Result<(u128, u128), MathError> {
-    let r_token_out_amount = amount_to_rated(token_out_amount, rates[token_out_idx])?;
+    let r_token_out_amount = amount_to_rated(token_out_amount, rates[token_out_id])?;
     let r_current_reserves = amounts_to_rated(current_reserves, rates)?;
     let (r_dy, r_fee) = swap_from(
-        token_in_idx,
+        token_in_id,
         r_token_out_amount,
-        token_out_idx,
+        token_out_id,
         &r_current_reserves,
         fees,
         amp_coef,
     )?;
     // add one in case of rounding error, for the protocol advantage
-    let dy = amount_from_rated(r_dy, rates[token_in_idx])?
+    let dy = amount_from_rated(r_dy, rates[token_in_id])?
         .checked_add(1)
         .ok_or(MathError::AddOverflow(12))?;
-    let fee = amount_from_rated(r_fee, rates[token_out_idx])?;
+    let fee = amount_from_rated(r_fee, rates[token_out_id])?;
     Ok((dy, fee))
 }
 
-/// Given `deposit_amounts` user want deposit, calculates how many LPT
-/// is required to be burnt (lpt_mint_for_user, fee_part)
+/// Given `deposit_amounts` user want deposit, calculates how many lpt
+/// is required to be burnt.
+/// Returns a tuple of (lpt to mint, fee)
 fn compute_lp_amount_for_deposit(
     deposit_amounts: &Vec<u128>,
     old_reserves: &Vec<u128>,
@@ -456,8 +457,9 @@ pub fn compute_amounts_given_lp(
     Ok(amounts)
 }
 
-/// Given `withdraw_amounts` user want get, calculates how many LPT
-/// is required to be burnt (total_to_burn, fee_part)
+/// Given `withdraw_amounts` user want get, calculates how many lpt
+/// is required to be burnt
+/// Returns a tuple of (lpt to burn, fee part)
 fn compute_lp_amount_for_withdraw(
     withdraw_amounts: &[u128],
     old_reserves: &Vec<u128>,


### PR DESCRIPTION
This PR combines `StablePool` and `StablePoolView` into one trait. It also introduces a few less significant changes:
- refactor "getter" function so they don't require `&mut self`
- rewrite some comments and function names