### PR TITLE
Disallow deposit/withdrawal when all amounts are 0

### DIFF
--- a/amm/contracts/stable_pool/lib.rs
+++ b/amm/contracts/stable_pool/lib.rs
@@ -540,7 +540,7 @@ pub mod stable_pool {
             // Check that at least one amount is non-zero
             ensure!(
                 amounts.iter().any(|&amount| amount > 0),
-                StablePoolError::InsufficientAmounts
+                StablePoolError::ZeroAmounts
             );
 
             // Make sure rates are up to date before we attempt any calculations
@@ -630,7 +630,7 @@ pub mod stable_pool {
             // Check that at least one amount is non-zero
             ensure!(
                 amounts.iter().any(|&amount| amount > 0),
-                StablePoolError::InsufficientAmounts
+                StablePoolError::ZeroAmounts
             );
 
             // transfer tokens
@@ -675,7 +675,7 @@ pub mod stable_pool {
             // Check that at least one amount is non-zero
             ensure!(
                 amounts.iter().any(|&amount| amount > 0),
-                StablePoolError::InsufficientAmounts
+                StablePoolError::ZeroAmounts
             );
 
             let rates = self.get_scaled_rates()?;

--- a/amm/contracts/stable_pool/lib.rs
+++ b/amm/contracts/stable_pool/lib.rs
@@ -537,6 +537,11 @@ pub mod stable_pool {
                 amounts.len() == self.pool.tokens.len(),
                 StablePoolError::IncorrectAmountsCount
             );
+            // Check that at least one amount is non-zero
+            ensure!(
+                amounts.iter().any(|&amount| amount > 0),
+                StablePoolError::InsufficientAmounts
+            );
 
             // Make sure rates are up to date before we attempt any calculations
             let rates = self.get_scaled_rates()?;
@@ -559,12 +564,14 @@ pub mod stable_pool {
 
             // transfer amounts
             for (id, &token) in self.pool.tokens.iter().enumerate() {
-                self.token_by_address(token).transfer_from(
-                    self.env().caller(),
-                    self.env().account_id(),
-                    amounts[id],
-                    vec![],
-                )?;
+                if amounts[id] > 0 {
+                    self.token_by_address(token).transfer_from(
+                        self.env().caller(),
+                        self.env().account_id(),
+                        amounts[id],
+                        vec![],
+                    )?;
+                }
             }
 
             // mint shares
@@ -620,10 +627,17 @@ pub mod stable_pool {
                     .all(|(amount, min_amount)| amount >= min_amount),
                 StablePoolError::InsufficientOutputAmount
             );
+            // Check that at least one amount is non-zero
+            ensure!(
+                amounts.iter().any(|&amount| amount > 0),
+                StablePoolError::InsufficientAmounts
+            );
 
             // transfer tokens
             for (&token, &amount) in self.pool.tokens.iter().zip(amounts.iter()) {
-                self.token_by_address(token).transfer(to, amount, vec![])?;
+                if amount > 0 {
+                    self.token_by_address(token).transfer(to, amount, vec![])?;
+                }
             }
 
             // update reserves
@@ -658,6 +672,11 @@ pub mod stable_pool {
                 amounts.len() == self.pool.tokens.len(),
                 StablePoolError::IncorrectAmountsCount
             );
+            // Check that at least one amount is non-zero
+            ensure!(
+                amounts.iter().any(|&amount| amount > 0),
+                StablePoolError::InsufficientAmounts
+            );
 
             let rates = self.get_scaled_rates()?;
 
@@ -689,7 +708,9 @@ pub mod stable_pool {
             }
             // transfer tokens
             for (&token, &amount) in self.pool.tokens.iter().zip(amounts.iter()) {
-                self.token_by_address(token).transfer(to, amount, vec![])?;
+                if amount > 0 {
+                    self.token_by_address(token).transfer(to, amount, vec![])?;
+                }
             }
             // update reserves
             for (i, &amount) in amounts.iter().enumerate() {

--- a/amm/drink-tests/src/stable_swap_tests/tests_add_remove_lp.rs
+++ b/amm/drink-tests/src/stable_swap_tests/tests_add_remove_lp.rs
@@ -1280,7 +1280,7 @@ fn test_for_zero_deposit(mut session: Session) {
 
     assert_eq!(
         err,
-        StablePoolError::InsufficientAmounts(),
+        StablePoolError::ZeroAmounts(),
         "Should return appropriate error"
     );
 
@@ -1339,7 +1339,7 @@ fn test_for_zero_withdrawal(mut session: Session) {
 
     assert_eq!(
         err,
-        StablePoolError::InsufficientAmounts(),
+        StablePoolError::ZeroAmounts(),
         "Should return appropriate error"
     );
 
@@ -1355,7 +1355,7 @@ fn test_for_zero_withdrawal(mut session: Session) {
 
     assert_eq!(
         err,
-        StablePoolError::InsufficientAmounts(),
+        StablePoolError::ZeroAmounts(),
         "Should return appropriate error"
     );
 

--- a/amm/drink-tests/src/stable_swap_tests/tests_add_remove_lp.rs
+++ b/amm/drink-tests/src/stable_swap_tests/tests_add_remove_lp.rs
@@ -1225,3 +1225,147 @@ fn test_lp_withdraw_all_but_no_more() {
     )
     .expect_err("Should not successfully remove liquidity");
 }
+
+#[drink::test]
+fn test_for_zero_deposit(mut session: Session) {
+    seed_account(&mut session, CHARLIE);
+    seed_account(&mut session, DAVE);
+    seed_account(&mut session, EVA);
+
+    let initial_reserves = vec![100000 * ONE_DAI, 100000 * ONE_USDT, 100000 * ONE_USDC];
+    let initial_supply = initial_reserves
+        .iter()
+        .map(|amount| amount * 100_000_000_000)
+        .collect::<Vec<u128>>();
+    let (stable_swap, tokens) = setup_stable_swap_with_tokens(
+        &mut session,
+        vec![18, 6, 6],
+        initial_supply.clone(),
+        10_000,
+        2_500_000,
+        200_000_000,
+        BOB,
+        vec![],
+    );
+
+    _ = stable_swap::add_liquidity(
+        &mut session,
+        stable_swap,
+        BOB,
+        1,
+        initial_reserves.clone(),
+        bob(),
+    )
+    .expect("Should successfully add liquidity");
+
+    // setup max allowance for stable swap contract on both tokens
+    transfer_and_increase_allowance(
+        &mut session,
+        stable_swap,
+        tokens.clone(),
+        CHARLIE,
+        vec![500 * ONE_DAI, 500 * ONE_USDT, 500 * ONE_USDC],
+        BOB,
+    );
+
+    let err = stable_swap::add_liquidity(
+        &mut session,
+        stable_swap,
+        CHARLIE,
+        0,
+        vec![0, 0, 0],
+        charlie(),
+    )
+    .expect_err("Should return an error");
+
+    assert_eq!(
+        err,
+        StablePoolError::InsufficientAmounts(),
+        "Should return appropriate error"
+    );
+
+    _ = stable_swap::add_liquidity(
+        &mut session,
+        stable_swap,
+        CHARLIE,
+        0,
+        vec![1, 0, 0],
+        charlie(),
+    )
+    .expect("Should min liqudity");
+}
+
+#[drink::test]
+fn test_for_zero_withdrawal(mut session: Session) {
+    seed_account(&mut session, CHARLIE);
+    seed_account(&mut session, DAVE);
+    seed_account(&mut session, EVA);
+
+    let initial_reserves = vec![100000 * ONE_DAI, 100000 * ONE_USDT, 100000 * ONE_USDC];
+    let initial_supply = initial_reserves
+        .iter()
+        .map(|amount| amount * 100_000_000_000)
+        .collect::<Vec<u128>>();
+    let (stable_swap, _) = setup_stable_swap_with_tokens(
+        &mut session,
+        vec![18, 6, 6],
+        initial_supply.clone(),
+        10_000,
+        2_500_000,
+        200_000_000,
+        BOB,
+        vec![],
+    );
+
+    _ = stable_swap::add_liquidity(
+        &mut session,
+        stable_swap,
+        BOB,
+        1,
+        initial_reserves.clone(),
+        bob(),
+    )
+    .expect("Should successfully add liquidity");
+
+    let err = stable_swap::remove_liquidity_by_shares(
+        &mut session,
+        stable_swap,
+        BOB,
+        1,
+        vec![0, 0, 0],
+        bob(),
+    )
+    .expect_err("Should return an error");
+
+    assert_eq!(
+        err,
+        StablePoolError::InsufficientAmounts(),
+        "Should return appropriate error"
+    );
+
+    let err = stable_swap::remove_liquidity_by_amounts(
+        &mut session,
+        stable_swap,
+        BOB,
+        0,
+        vec![0, 0, 0],
+        bob(),
+    )
+    .expect_err("Should return an error");
+
+    assert_eq!(
+        err,
+        StablePoolError::InsufficientAmounts(),
+        "Should return appropriate error"
+    );
+
+    _ = stable_swap::remove_liquidity_by_amounts(
+        &mut session,
+        stable_swap,
+        BOB,
+        1,
+        vec![1, 0, 0],
+        bob(),
+    )
+    .expect("Should burn liquidity");
+}

--- a/amm/drink-tests/src/stable_swap_tests/tests_swap_exact_in_received.rs
+++ b/amm/drink-tests/src/stable_swap_tests/tests_swap_exact_in_received.rs
@@ -165,7 +165,7 @@ fn test_swap_exact_in(
         [0, expected_protocol_fee_part].to_vec(),
         bob(),
     )
-    .expect("swap_exact_in: Should remove liquidity");
+    .unwrap_or((0, 0));
     assert_eq!(
         total_lp_required - lp_fee_part,
         protocol_fee_lp,
@@ -181,7 +181,7 @@ fn test_swap_exact_in(
         [0, expected_protocol_fee_part].to_vec(),
         bob(),
     )
-    .expect("swap_received: Should remove liquidity");
+    .unwrap_or((0, 0));
     assert_eq!(
         total_lp_required - lp_fee_part,
         protocol_fee_lp,

--- a/amm/traits/stable_pool.rs
+++ b/amm/traits/stable_pool.rs
@@ -235,7 +235,7 @@ pub enum StablePoolError {
     InvalidTokenId(AccountId),
     IdenticalTokenId,
     IncorrectAmountsCount,
-    InvalidAmpCoef,
+    InsufficientAmounts,
     InsufficientLiquidityMinted,
     InsufficientLiquidityBurned,
     InsufficientOutputAmount,

--- a/amm/traits/stable_pool.rs
+++ b/amm/traits/stable_pool.rs
@@ -235,7 +235,7 @@ pub enum StablePoolError {
     InvalidTokenId(AccountId),
     IdenticalTokenId,
     IncorrectAmountsCount,
-    InsufficientAmounts,
+    ZeroAmounts,
     InsufficientLiquidityMinted,
     InsufficientLiquidityBurned,
     InsufficientOutputAmount,


### PR DESCRIPTION
This PR adds:
- A check to deposit and withdrawal methods. The check ensures that at least one deposit/withdrawal token amount is non-zero. 
- A check before token transfer. The check ensures the token amount is non-zero to avoid unnecessary cross-contract calls.